### PR TITLE
Remove `var colors` declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 'use strict';
 
+require('colors');
+
 var npm = require('./lib/npm'),
     args = require('argh').argv,
     readline = require('readline'),
     Q = require('q'),
-    color = require('colors'),
     installOptions = {
         save: args.save || false,
         dev: args.dev || false


### PR DESCRIPTION
- Quietens the linter, we're not using var colors so let's just require it

![](https://s3.amazonaws.com/f.cl.ly/items/1j1a0Q1R3y1Z3u2P2u04/Screen%20Shot%202015-12-09%20at%2016.07.49.png?v=518930d6)