### PR TITLE
Send `--help` 🆘

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Bramble will then download the latest version of that dependency, optionally (wi
 new version. Finally, Bramble will (with the --save flag) write the new version
 to your package.json.
 
-He's also my cat.
+He's also [Ben's](https://github.com/easternbloc/) cat.
 
 ![bramble cat!](http://cl.ly/image/1g2c1B2h3l0c/bramble.jpg)
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ npm install bramble --save
 
 ```
 Usage: bramble [--save] [--prompt] [--test] [--dev]
-Usage: node index.js [--save] [--prompt] [--test] [--dev]
 
---save      save the package.json on a successful install (and optional --test from your package.json)
---prompt    prompt the user to install/skip and optionally test each dependency that needs updating
---test      bramble will run 'npm test' (defined in your package.json) for you after successful install of any dependencies.
-            If the tests fail bramble will revert (reinstall) your previous installed package(s)
---dev       flag to update your devDependencies
+  Options:
+
+    -h, --help     output usage information
+    -V, --version  output the version number
+    -s, --save     save the package.json on a successful install (and optional --test from your package.json
+    -t, --test     bramble will run "npm test" (defined in your package.json) for you after successful install of any dependencies.
+    -p, --prompt   prompt the user to install/skip and optionally test each dependency that needs updating
+    -d, --dev      include flag to also update your devDependencies
 ```

--- a/bin/bramble
+++ b/bin/bramble
@@ -1,3 +1,19 @@
 #!/usr/bin/env node
 
-require('../index');
+var command = require('commander');
+var pkg = require('../package.json');
+var bramble = require('../index');
+
+command
+    .usage('[--save] [--prompt] [--test] [--dev]')
+    .version(pkg.version)
+    .description(pkg.description)
+    .option('-s, --save', 'save the package.json on a successful install (and optional --test from your package.json')
+    .option('-t, --test', 'bramble will run "npm test" (defined in your package.json) for you after successful install of any dependencies.')
+    .option('-p, --prompt', 'prompt the user to install/skip and optionally test each dependency that needs updating')
+    .option('-d, --dev', 'include flag to also update your devDependencies')
+    ;
+
+command.parse(process.argv);
+
+bramble(command);

--- a/index.js
+++ b/index.js
@@ -3,104 +3,109 @@
 require('colors');
 
 var npm = require('./lib/npm'),
-    args = require('argh').argv,
     readline = require('readline'),
     Q = require('q'),
-    installOptions = {
-        save: args.save || false,
-        dev: args.dev || false
-    },
     path = require('path'),
     packageJson = require(path.resolve(process.cwd(), './package.json'));
 
-npm.list(packageJson, args.dev)
-    .then(function (packages) {
-        return npm.outdated(packages);
-    })
-    .then(function (outdatedPackages) {
-        if (args.prompt) {
-            var rl = readline.createInterface({
-                input: process.stdin,
-                output: process.stdout
-            });
+var run = function bramble (args) {
 
-            var fns = outdatedPackages.map(function (pack) {
-                if (pack[2] !== pack[4]) {
-                    var latestPackage = pack[1] + '@' + pack[4];
-                    var previousPackage = pack[1] + '@' + pack[2];
+    var installOptions = {
+        save: args.save || false,
+        dev: args.dev || false
+    };
 
-                    return function () {
-                        var deferred = Q.defer();
-                        console.log('Do you want to upgrade the package ' + previousPackage.green + ' to the latest version ' + latestPackage.green + ' (Y/N/T): ');
-                        rl.question('', function (answer) {
-                            if (answer.toLowerCase().indexOf('y') !== -1) {
-                                npm.install(latestPackage, installOptions)
-                                    .then(function () {
-                                        if (args.test || answer.toLowerCase().indexOf('t') !== -1) {
-                                            return npm.test();
-                                        } else {
-                                            return new Q();
-                                        }
-                                    }, function () {
-                                        console.log(('NPM install failed for ' + latestPackage).red);
-                                        return deferred.reject();
-                                    })
-                                    .then(deferred.resolve, function () {
-                                        console.log(('NPM tests failed for ' + latestPackage + ' restoring to old version ' + previousPackage).red);
-                                        return npm.install(previousPackage, installOptions).then(deferred.resolve, deferred.reject);
-                                    });
-                            } else {
-                                deferred.resolve();
-                            }
-                        });
-                        return deferred.promise;
-                    };
-                } else {
-                    return new Q();
-                }
-            });
-
-            return fns.reduce(Q.when, new Q()).then(function () {
-                rl.close();
-            });
-        } else {
-            if (outdatedPackages.length > 0) {
-                //install everything at once
-                var packagesToUpdate = [],
-                    previousPackages = [];
-
-                outdatedPackages.forEach(function (pack) {
-                    packagesToUpdate.push(pack[1] + '@' + pack[4]);
-                    previousPackages.push(pack[1] + '@' + pack[2]);
+    npm.list(packageJson, args.dev)
+        .then(function (packages) {
+            return npm.outdated(packages);
+        })
+        .then(function (outdatedPackages) {
+            if (args.prompt) {
+                var rl = readline.createInterface({
+                    input: process.stdin,
+                    output: process.stdout
                 });
 
-                console.log(('Installing the latest packages ' + packagesToUpdate.toString().replace(',', ', ')).green);
+                var fns = outdatedPackages.map(function (pack) {
+                    if (pack[2] !== pack[4]) {
+                        var latestPackage = pack[1] + '@' + pack[4];
+                        var previousPackage = pack[1] + '@' + pack[2];
 
-                return npm.install(packagesToUpdate, installOptions)
-                    .then(function () {
-                        if (args.test) {
-                            return npm.test();
-                        } else {
-                            return new Q();
-                        }
-                    }, function (err) {
-                        console.log(('NPM install failed').red);
-                        throw err;
-                    })
-                    .fail(function () {
-                        console.log(('NPM tests failed restoring to old versions ' + previousPackages.toString().replace(',', ', ')).red);
-                        return npm.install(previousPackages, installOptions).fail(function (err) { throw err; });
-                    });
+                        return function () {
+                            var deferred = Q.defer();
+                            console.log('Do you want to upgrade the package ' + previousPackage.green + ' to the latest version ' + latestPackage.green + ' (Y/N/T): ');
+                            rl.question('', function (answer) {
+                                if (answer.toLowerCase().indexOf('y') !== -1) {
+                                    npm.install(latestPackage, installOptions)
+                                        .then(function () {
+                                            if (args.test || answer.toLowerCase().indexOf('t') !== -1) {
+                                                return npm.test();
+                                            } else {
+                                                return new Q();
+                                            }
+                                        }, function () {
+                                            console.log(('NPM install failed for ' + latestPackage).red);
+                                            return deferred.reject();
+                                        })
+                                        .then(deferred.resolve, function () {
+                                            console.log(('NPM tests failed for ' + latestPackage + ' restoring to old version ' + previousPackage).red);
+                                            return npm.install(previousPackage, installOptions).then(deferred.resolve, deferred.reject);
+                                        });
+                                } else {
+                                    deferred.resolve();
+                                }
+                            });
+                            return deferred.promise;
+                        };
+                    } else {
+                        return new Q();
+                    }
+                });
+
+                return fns.reduce(Q.when, new Q()).then(function () {
+                    rl.close();
+                });
             } else {
-                console.log('Nothing to update!');
-                return new Q();
+                if (outdatedPackages.length > 0) {
+                    //install everything at once
+                    var packagesToUpdate = [],
+                        previousPackages = [];
+
+                    outdatedPackages.forEach(function (pack) {
+                        packagesToUpdate.push(pack[1] + '@' + pack[4]);
+                        previousPackages.push(pack[1] + '@' + pack[2]);
+                    });
+
+                    console.log(('Installing the latest packages ' + packagesToUpdate.toString().replace(',', ', ')).green);
+
+                    return npm.install(packagesToUpdate, installOptions)
+                        .then(function () {
+                            if (args.test) {
+                                return npm.test();
+                            } else {
+                                return new Q();
+                            }
+                        }, function (err) {
+                            console.log(('NPM install failed').red);
+                            throw err;
+                        })
+                        .fail(function () {
+                            console.log(('NPM tests failed restoring to old versions ' + previousPackages.toString().replace(',', ', ')).red);
+                            return npm.install(previousPackages, installOptions).fail(function (err) { throw err; });
+                        });
+                } else {
+                    console.log('Nothing to update!');
+                    return new Q();
+                }
             }
-        }
-    })
-    .then(function () {
-        console.log('Finished!');
-        process.exit(0);
-    }, function () {
-        console.log('Failed!');
-        process.exit(1);
-    });
+        })
+        .then(function () {
+            console.log('Finished!');
+            process.exit(0);
+        }, function () {
+            console.log('Failed!');
+            process.exit(1);
+        });
+};
+
+module.exports = run;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bramble",
   "description": "A tool which helps you safely upgrade your NPM dependencies.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": [
     "npm",
     "build",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     {
       "name": "Leonard Martin",
       "email": "hello@lennym.co.uk"
+    },
+    {
+      "name": "Ralph Cowling",
+      "email": "ralph@ralph-cowling.com"
     }
   ],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "test": "mocha --reporter tap test"
   },
   "dependencies": {
-    "argh": "0.1.4",
     "colors": "1.1.2",
+    "commander": "2.9.0",
     "npm": "3.5.1",
     "q": "1.4.1",
     "semver": "5.1.0"


### PR DESCRIPTION
I feel like you should be able to know what you're getting yourself into when you run a program from the internet. The common usage of `--help` is what I was looking for but couldn't find it, so I'm adding it in here.

### Uses commander not argh

- Uses [commander](https://github.com/tj/commander.js) to parse arguments and to provide help
- With commander in place, argh is not longer needed, so it's removed here
- Updates the `README` to show new usage
- `index.js` now exports a `run` command, which takes options from commander

### Add Ralph to the contributors list

- fame!
- Infamy!


### Updates version to 1.0.2

- All commands should function as before
